### PR TITLE
pin centrosome

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -37,4 +37,5 @@ dependencies:
   - pip:
     - omero-py
     - cellh5
+    - centrosome==1.1.6
     - git+https://github.com/CellProfiler/CellProfiler.git@v3.1.9


### PR DESCRIPTION
A new version of centrosome was released in march.
The version broke the installation of CP
```
centrosome-1.1.7.tar.gz (543kB)
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-install-OSciKW/centrosome/setup.py", line 84
        **__extkwargs,
                     ^
    SyntaxError: invalid syntax

```
pinning the version fo 1.1.6

* Check that the build is green

cc @pwalczysko 